### PR TITLE
Make Citecommand for cite from Zotero optional

### DIFF
--- a/src/components/zotero.ts
+++ b/src/components/zotero.ts
@@ -148,7 +148,7 @@ export class Zotero {
                 const latexCommand = configuration.get('latexCommand') as string
 
                 const keys = entries.map(e => e.citekey).join(',')
-                return `\\${latexCommand}{${keys}}`
+                return latexCommand.length > 0 ?`\\${latexCommand}{${keys}}` : `${keys}`
             } else {
                 return null
             }


### PR DESCRIPTION
Added a check to see if the latex-utilities.zotero.latexCommand is set, if it is empty will only insert the keys. This is useful when inserting keys into large multicite commands e.g.: `\parencites(vgl.)()[][page]{2:key}[][page2]{key2}`